### PR TITLE
add missing dependency, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ To run `ell-studio` you must seperately run the backend and the front-end. To st
 ```
 cd ell-studio
 npm run dev
+npm run start:dev
 ```
 To start the backend: 
 ```

--- a/ell-studio/package-lock.json
+++ b/ell-studio/package-lock.json
@@ -24,7 +24,7 @@
         "react-icons": "^5.2.1",
         "react-markdown": "^9.0.1",
         "react-router-dom": "^6.18.0",
-        "react-scripts": "5.0.1",
+        "react-scripts": "^5.0.1",
         "react-syntax-highlighter": "^15.5.0",
         "reactflow": "^11.11.4",
         "web-vitals": "^2.1.4"

--- a/ell-studio/package.json
+++ b/ell-studio/package.json
@@ -19,7 +19,7 @@
     "react-icons": "^5.2.1",
     "react-markdown": "^9.0.1",
     "react-router-dom": "^6.18.0",
-    "react-scripts": "5.0.1",
+    "react-scripts": "^5.0.1",
     "react-syntax-highlighter": "^15.5.0",
     "reactflow": "^11.11.4",
     "web-vitals": "^2.1.4"


### PR DESCRIPTION
`pip install .` was breaking because `react-scripts` was not in `package.json`, added the dependency explicitly, and updated the README since it is referencing a non-existant `npm run` target