### PR TITLE
add missing dependency requests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ openai
 fastapi
 sqlmodel
 uvicorn
+requests


### PR DESCRIPTION
Requests needed to run `ollama`

```
Traceback (most recent call last):
  File "$HOME/projects/ell-fork/examples/hello_world.py", line 1, in <module>
    import ell
  File "$HOME/projects/ell-fork/src/ell/__init__.py", line 5, in <module>
    import ell.models
  File "$HOME/projects/ell-fork/src/ell/models/__init__.py", line 2, in <module>
    import ell.models.ollama
  File "$HOME/projects/ell-fork/src/ell/models/ollama.py", line 3, in <module>
    import requests
ModuleNotFoundError: No module named 'requests'
```

added to `requirements.txt` issue resolved.