### PR TITLE
Typofix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Prompt engineering goes from a dark art to a science with the right tools. **Ell
   <source srcset="https://docs.ell.so/_static/ell_studio_better.webp" type="image/webp">
   <img src="docs/src/_static/ell_studio_better.webp" alt="ell studio demonstration">
 </picture>
+
 ```bash
 ell-studio --storage ./logdir 
 ```


### PR DESCRIPTION
fix minor typo so ell-studio command renders properly in readme

## Before

<img width="1151" alt="image" src="https://github.com/user-attachments/assets/3264a4c2-86c8-4e08-ad18-cefe901de36e">

## After

<img width="1040" alt="image" src="https://github.com/user-attachments/assets/75acb080-0777-4c51-a11d-47be54fd3e3b">