### PR TITLE
[Docs] Correct getting started typo

### DIFF
--- a/docs/src/getting_started.rst
+++ b/docs/src/getting_started.rst
@@ -98,7 +98,7 @@ While the previous example used the docstring for the system message and the ret
     greeting = hello("Sam Altman")
     print(greeting)
 
-This approach allows you to construct more complex conversations within your LMP. Importantly, you'll want to use this approach when you have a variable system prompt because python only allows you to have a static system prompt.
+This approach allows you to construct more complex conversations within your LMP. Importantly, you'll want to use this approach when you have a variable system prompt because python only allows you to have a static docstring.
 
 Prompting as Language Model Programming
 ----------------------------------------


### PR DESCRIPTION
I believe the second "system prompt" in this sentence is supposed to be "docstring".