### PR TITLE
Enable image_detail on ContentBlock for OpenAI

### DIFF
--- a/src/ell/providers/openai.py
+++ b/src/ell/providers/openai.py
@@ -18,11 +18,16 @@ try:
         def content_block_to_openai_format(content_block: ContentBlock) -> Dict[str, Any]:
             if content_block.image:
                 base64_image = serialize_image(content_block.image)
+                image_url = {"url": base64_image}
+
+                # add detail only if supplied by user
+                # OpenAI's default is "auto", we omit the "detail" key entirely if not provided by user
+                if content_block.image_detail:
+                    image_url["detail"] = content_block.image_detail
+
                 return {
                     "type": "image_url",
-                    "image_url": {
-                        "url": base64_image
-                    }
+                    "image_url": image_url
                 }
             elif content_block.text:
                 return {

--- a/src/ell/types/message.py
+++ b/src/ell/types/message.py
@@ -48,6 +48,7 @@ class ContentBlock(BaseModel):
     
     text: Optional[_lstr_generic] = Field(default=None)
     image: Optional[Union[PILImage.Image, str, np.ndarray]] = Field(default=None)
+    image_detail: Optional[str] = Field(default=None)
     audio: Optional[Union[np.ndarray, List[float]]] = Field(default=None)
     tool_call: Optional[ToolCall] = Field(default=None)
     parsed: Optional[BaseModel] = Field(default=None)
@@ -56,8 +57,9 @@ class ContentBlock(BaseModel):
     @model_validator(mode='after')
     def check_single_non_null(self):
         non_null_fields = [field for field, value in self.__dict__.items() if value is not None]
-        if len(non_null_fields) > 1:
-            raise ValueError(f"Only one field can be non-null. Found: {', '.join(non_null_fields)}")
+        # need to allow for image_detail to be set with an image
+        if len(non_null_fields) > 1 and set(non_null_fields) != {'image', 'image_detail'}:
+            raise ValueError(f"Only one field can be non-null (except for image with image_detail). Found: {', '.join(non_null_fields)}")
         return self
 
     @property


### PR DESCRIPTION
`image_detail` param within OpenAI's API is not handled within the `api_params` of the ell decorators. This PR fixes that by adding `image_detail` to the `ContentBlock` object to give a developer more granular control of their image quality rather than associating it at the top level via the decorator.

Consider the following Message:
```
ell.Message(role="user", content=["You are a helpful assistant that takes in images and returns a description of the image.",
ell.ContentBlock(image=x, image_detail="low"), ell.ContentBlock(image=x, image_detail="high"), ell.ContentBlock(image=x)])
```

Linked here on [Discord](https://discord.com/channels/1266849047314960394/1266849239913463998/1284220273758965760)

Stemming from this [issue](https://discord.com/channels/1266849047314960394/1266849239913463998/1284194202036600873)