### PR TITLE
Resolve unknown message role exceptions

### DIFF
--- a/src/ell/providers/openai.py
+++ b/src/ell/providers/openai.py
@@ -182,6 +182,9 @@ try:
                                 )
                             )
                         )
+
+                    # Determine the role for streaming responses, defaulting to 'assistant' if not provided
+                    streamed_role = next((choice.delta.role for choice in choice_deltas if choice.delta.role), 'assistant')
                 else:
                     choice = choice_deltas[0].message
                     if choice.refusal:
@@ -229,7 +232,7 @@ try:
                         role=(
                             choice.role
                             if not call_result.actual_streaming
-                            else choice_deltas[0].delta.role
+                            else streamed_role
                         ),
                         content=content,
                     )


### PR DESCRIPTION
### Summary

This PR resolves a Pydantic value error exception that can occur when the streamed response from an OpenAI-like service does not produce a `role` in the initial chunk. A default role of `assistant` is used when a role is not found. The message composition now uses this `role` if the call result is flagged as `actual_streaming`.

- [Issue 175](https://github.com/MadcowD/ell/issues/175)

### Changes

- updates OpenAI `process_response` to extract `role` with default