### PR TITLE
Fix syntax error in installation.rst

### DIFF
--- a/docs/src/installation.rst
+++ b/docs/src/installation.rst
@@ -14,7 +14,7 @@ Installing ell
 
    By default, this installs only the OpenAI client SDK. If you want to include the Anthropic client SDK, use the "anthropic" extra like so:
 
-      .. code-block:: bash
+   .. code-block:: bash
 
       pip install -U ell-ai[anthropic]
 


### PR DESCRIPTION
Fixes anthropic installation command being rendered as a quote block:

<img width="774" alt="image" src="https://github.com/user-attachments/assets/52c814d7-6483-4f7c-b403-a938b5e204c8">

