### PR TITLE
Repair openai dependency inclusion regression.

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -704,13 +704,13 @@ zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "huggingface-hub"
-version = "0.25.0"
+version = "0.25.1"
 description = "Client library to download and publish models, datasets and other repos on the huggingface.co hub"
 optional = true
 python-versions = ">=3.8.0"
 files = [
-    {file = "huggingface_hub-0.25.0-py3-none-any.whl", hash = "sha256:e2f357b35d72d5012cfd127108c4e14abcd61ba4ebc90a5a374dc2456cb34e12"},
-    {file = "huggingface_hub-0.25.0.tar.gz", hash = "sha256:fb5fbe6c12fcd99d187ec7db95db9110fb1a20505f23040a5449a717c1a0db4d"},
+    {file = "huggingface_hub-0.25.1-py3-none-any.whl", hash = "sha256:a5158ded931b3188f54ea9028097312cb0acd50bffaaa2612014c3c526b44972"},
+    {file = "huggingface_hub-0.25.1.tar.gz", hash = "sha256:9ff7cb327343211fbd06e2b149b8f362fd1e389454f3f14c6db75a4999ee20ff"},
 ]
 
 [package.dependencies]
@@ -1064,13 +1064,13 @@ files = [
 
 [[package]]
 name = "openai"
-version = "1.47.0"
+version = "1.47.1"
 description = "The official Python library for the openai API"
 optional = false
 python-versions = ">=3.7.1"
 files = [
-    {file = "openai-1.47.0-py3-none-any.whl", hash = "sha256:9ccc8737dfa791f7bd903db4758c176b8544a8cd89d3a3d2add3cea02a34c3a0"},
-    {file = "openai-1.47.0.tar.gz", hash = "sha256:6e14d6f77c8cf546646afcd87a2ef752505b3710d2564a2e433e17307dfa86a0"},
+    {file = "openai-1.47.1-py3-none-any.whl", hash = "sha256:34277583bf268bb2494bc03f48ac123788c5e2a914db1d5a23d5edc29d35c825"},
+    {file = "openai-1.47.1.tar.gz", hash = "sha256:62c8f5f478f82ffafc93b33040f8bb16a45948306198bd0cba2da2ecd9cf7323"},
 ]
 
 [package.dependencies]
@@ -2311,12 +2311,11 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 type = ["pytest-mypy"]
 
 [extras]
-all = ["anthropic", "groq", "openai"]
+all = ["anthropic", "groq"]
 anthropic = ["anthropic"]
 groq = ["groq"]
-openai = ["openai"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9"
-content-hash = "621457432d7ef7d5348d1909b7dcc4feec959a7a46d9101687e4f76fd3e9dff8"
+content-hash = "92199b8a5bdf2716b6a6d12356504b41f7402c7f2bad53a2d853e0cdb3d7a345"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,10 +49,11 @@ sphinx = "<8.0.0"
 sphinx-rtd-theme = "^2.0.0"
 
 [tool.poetry.extras]
-openai = ["openai"]
+# N.B. The `openai` dep is always required, but explicitly providing it via an e.g. "openai" extra
+# causes poetry to mark it as optional = true (even if explicitly specified optional = false).
 anthropic = ["anthropic"]
 groq = ["groq"]
-all = ["openai", "anthropic", "groq"]
+all = ["anthropic", "groq"]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
Repairs a sub-dependency inclusion regression introduced in #199 due to unexpected `poetry` behavior.

Before (`openai` is only conditionally installed when the "openai" or "all" extra is specified):

```
om:ell kw$ git rev-parse HEAD
585b695a948d228f476c2facfb87a8950af98358
om:ell kw$ uvx poetry build
Building ell-ai (0.0.10)
  - Building sdist
  - Built ell_ai-0.0.10.tar.gz
  - Building wheel
  - Built ell_ai-0.0.10-py3-none-any.whl
om:ell kw$ unzip -p ./dist/ell_ai-0.0.10-py3-none-any.whl ell_ai-0.0.10.dist-info/METADATA | grep openai
Provides-Extra: openai
Requires-Dist: openai (>=1.47.0,<2.0.0) ; extra == "openai" or extra == "all"
om:ell kw$
```

After (`openai` is always installed):

```
om:ell kw$ uvx poetry build
Building ell-ai (0.0.10)
  - Building sdist
  - Built ell_ai-0.0.10.tar.gz
  - Building wheel
  - Built ell_ai-0.0.10-py3-none-any.whl
om:ell kw$ unzip -p ./dist/ell_ai-0.0.10-py3-none-any.whl ell_ai-0.0.10.dist-info/METADATA | grep openai
Requires-Dist: openai (>=1.47.0,<2.0.0)
om:ell kw$ 
```
