### PR TITLE
WIP: Introduce a new ell.interactive API and example.

### DIFF
--- a/examples/interactive_tool_diff.py
+++ b/examples/interactive_tool_diff.py
@@ -52,7 +52,6 @@ def diff_loop(prompts: str, glob: str, repo: str = ".", max_loops: int = 3):
   Your changes will be written to the filesystem using relative paths. You are in the root directory of the repository.
   Test application of the changes by calling the `apply_diff` tool with a valid unified diff (like `diff` or `git diff` would generate).
   This will store the patch, but won't apply it to the local filesystem - so always generate a completely new patch for every request.
-  ONLY generate code through the `apply_diff` tool. Don't output any code in the response - IT WILL BE IGNORED.
   Use chain-of-thought reasoning to generate the code and explain your work in your response.
   """)
 
@@ -85,7 +84,7 @@ def main():
     prompts=[
       "Add a simple argument parsing routine to interactive_tool_diff.py that provides a --help argument.",
       "Now extend the argument parsing so the user can specify a model name that will be printed when the file is invoked. Make it default to gpt4o-mini.",
-      "Now modify the diff_loop function in interactive_tool_diff.py to accept a model parameter that is passed via this CLI arg",
+      "Now modify the diff_loop function in interactive_tool_diff.py to accept a model parameter that is passed via this CLI arg.",
       "Now make the default argument for the model name be: claude-3-5-sonnet-20240620."
     ],
     glob="**/interactive_tool_diff.py",

--- a/examples/interactive_tool_diff.py
+++ b/examples/interactive_tool_diff.py
@@ -1,0 +1,93 @@
+import logging
+import subprocess
+from datetime import datetime
+from pathlib import Path
+from textwrap import dedent
+from typing import List
+
+import anthropic
+import ell
+from pydantic import Field
+
+
+logger = logging.getLogger(__name__)
+
+client = anthropic.Anthropic()
+
+
+def _validate_diff(diff: str) -> subprocess.CompletedProcess:
+  logger.info(f"Validating diff: {diff}")
+  return subprocess.run(
+    ["patch", "-p1", "--dry-run"],
+    input=diff.encode("utf-8"),
+    capture_output=True,
+    check=False
+  )
+
+
+@ell.tool()
+def apply_diff(
+  diff: str = Field(description="The unified diff to apply."),
+) -> str | None:
+  """Applies a unified diff to a local workspace using `patch -p1` and returns a natural language result."""
+  logger.info(f"Tool call: apply_diff")
+  result = _validate_diff(diff)
+  # TODO(kwlzn): Can we send a structured output to the LLM with e.g. tool_call_result.exit_code and stdout/stderr for it to natively interpret?
+  if result.returncode == 0:
+    logger.info("Tool call: apply_diff succeeded")
+    return f"Patch applied successfully: {result.stdout.decode()}"
+  else:
+    logger.warning("Tool call: apply_diff failed")
+    # Provide context to the LLM on the failure by proxying the output of `patch -p1`.
+    return f"That patch is invalid, can you try again with the correct diff syntax? Here's the output of `patch -p1`:\n{result.stderr.decode()}"
+
+
+def diff_loop(prompts: str, glob: str, repo: str = ".", max_loops: int = 3):
+  client = anthropic.Anthropic()
+  system_prompt = dedent("""\
+  You are a helpful, expert-level programmer that generates Python code changes to an existing codebase given a request.
+  Your changes will be written to the filesystem using relative paths. You are in the root directory of the repository.
+  Apply the changes by calling the `apply_diff` tool with a valid unified diff (like `diff` or `git diff` would generate).
+  Use chain-of-thought reasoning to generate the code and explain your work in your response.
+  Carefully analyze any tool call results for any syntax issues and make sure to correct them in your response.
+  """)
+  repo_path = Path(repo)
+  code_file = next(repo_path.glob(glob)).relative_to(repo_path)
+  code = f"<file:{code_file}>\n{code_file.read_text()}\n</file:{code_file}>"
+
+  with ell.interactive(
+    model="claude-3-5-sonnet-20240620",
+    client=client,
+    tools=[apply_diff],
+    max_tokens=1024,
+    temperature=0.5       # This seems to make Claude fail a few times before getting it right.
+  ) as session:
+    # Set the system prompt without making a request.
+    session.set_system_prompt(system_prompt)
+
+    for i, prompt in enumerate(prompts):
+      # Send the code context on the first message, but not subsequent ones.
+      if i == 0: prompt = f"{code}\n\n{prompt}"
+      session.send(prompt)
+
+
+def main():
+  logging.basicConfig(
+    format='%(asctime)s %(levelname)-8s] %(message)s',
+    level=logging.INFO,
+    datefmt='%Y-%m-%d %H:%M:%S'
+  )
+
+  ell.init(verbose=True, store="./ell_logs")
+
+  diff_loop(
+    prompts=[
+      "Add simple argument parsing to interactive_tool_diff.py so that a user can modify the max_loops parameter to the diff_loop function call with a -m flag when invoking from the CLI."
+    ],
+    glob="**/interactive_tool_diff.py",
+    max_loops=3
+  )
+
+
+if __name__ == "__main__":
+  main()

--- a/examples/interactive_tool_diff.py
+++ b/examples/interactive_tool_diff.py
@@ -50,7 +50,9 @@ def diff_loop(prompts: str, glob: str, repo: str = ".", max_loops: int = 3):
   system_prompt = dedent("""\
   You are a helpful, expert-level programmer that generates Python code changes to an existing codebase given a request.
   Your changes will be written to the filesystem using relative paths. You are in the root directory of the repository.
-  Apply the changes by calling the `apply_diff` tool with a valid unified diff (like `diff` or `git diff` would generate).
+  Test application of the changes by calling the `apply_diff` tool with a valid unified diff (like `diff` or `git diff` would generate).
+  This will store the patch, but won't apply it to the local filesystem - so always generate a completely new patch for every request.
+  ONLY generate code through the `apply_diff` tool. Don't output any code in the response - IT WILL BE IGNORED.
   Use chain-of-thought reasoning to generate the code and explain your work in your response.
   """)
 
@@ -59,7 +61,7 @@ def diff_loop(prompts: str, glob: str, repo: str = ".", max_loops: int = 3):
     client=client,
     tools=[apply_diff],
     max_tokens=1024,
-    temperature=0.5       # This seems to make Claude fail a few times before getting it right.
+    temperature=0.3
   ) as session:
     # Set the system prompt without making a request.
     session.set_system_prompt(system_prompt)
@@ -81,7 +83,10 @@ def main():
 
   diff_loop(
     prompts=[
-      "Add simple argument parsing to interactive_tool_diff.py so that a user can modify the max_loops parameter to the diff_loop function call with a -m flag when invoking from the CLI."
+      "Add a simple argument parsing routine to interactive_tool_diff.py that provides a --help argument.",
+      "Now extend the argument parsing so the user can specify a model name that will be printed when the file is invoked. Make it default to gpt4o-mini.",
+      "Now modify the diff_loop function in interactive_tool_diff.py to accept a model parameter that is passed via this CLI arg",
+      "Now make the default argument for the model name be: claude-3-5-sonnet-20240620."
     ],
     glob="**/interactive_tool_diff.py",
     max_loops=3

--- a/src/ell/__init__.py
+++ b/src/ell/__init__.py
@@ -7,6 +7,7 @@ and intuitive interface for working with large language models.
 from ell.lmp.simple import simple
 from ell.lmp.tool import tool
 from ell.lmp.complex import complex
+from ell.lmp.interactive import interactive
 from ell.types.message import system, user, assistant, Message, ContentBlock
 from ell.__version__ import __version__
 

--- a/src/ell/lmp/interactive.py
+++ b/src/ell/lmp/interactive.py
@@ -1,0 +1,33 @@
+from contextlib import contextmanager
+
+from .complex import complex as ell_complex
+from ..types import Chat
+
+
+@contextmanager
+def interactive(lmp, messages: List[Message]):
+  """Creates an interactive, append-mode session on top of an LMP function."""
+
+  @ell_complex(*args, **kwargs)
+  def interactive(messages: Chat) -> Chat:
+    return messages
+
+  class _InteractiveSession():
+    def __init__(self):
+      self._system_prompt = None
+      self._messages = messages[:]
+
+    def set_system_prompt(self, prompt):
+      self._system_prompt = prompt
+
+    def send(self, message = None):
+      if message:
+        self._messages.append(message)
+
+      return interactive(
+        [self._system_prompt] + self._messages
+      )
+
+  sess = _InteractiveSession()
+
+  yield session


### PR DESCRIPTION
This introduces `ell.interactive()`, a new experimental API helper for bi-directional interaction with an LMP which can be used for various interactive scenarios w/ contextual history. It uses python's context manager paradigm to provide a session-like object that accumulates all message types (system, user, assistant and tool call/results) - where the user only has to worry about examining the last response and sending the next one rather than managing that themselves.

I haven't thought too much about tracking/versioning nor have I tested it inside `ell studio` yet, but wanted to float the idea eagerly via a WIP PR for feedback/thoughts/guidance on how best to proceed in alignment with the projects goals.

Feedback welcome!