### PR TITLE
fix install command in readme?

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ```bash
 
-pip install -U ell-ai[all]
+pip install -U "ell-ai[all]"
 ```
 
 `ell` is a lightweight, functional prompt engineering framework built on a few core principles:


### PR DESCRIPTION
```
pip install -U ell-ai[all]
```

on `zsh` you get an error, this results in:

```
zsh: no matches found: ell-ai[all]  
```

This resolves it:

```
pip install -U "ell-ai[all]"
```

Should we change this or leave it alone? The former worked on bash.