### PR TITLE
Improve ell-studio CLI UX.

### DIFF
--- a/src/ell/studio/__main__.py
+++ b/src/ell/studio/__main__.py
@@ -1,13 +1,33 @@
 import asyncio
-import os
+import logging
+import socket
+import time
+import webbrowser
 import uvicorn
 from argparse import ArgumentParser
+from contextlib import closing
 from ell.studio.config import Config
 from ell.studio.server import create_app
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
+from pathlib import Path
 from watchfiles import awatch
-import time
+
+
+logger = logging.getLogger(__file__)
+
+
+def _socket_is_open(host, port) -> bool:
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+        return sock.connect_ex((host, port)) == 0
+
+
+def _setup_logging(level):
+    logging.basicConfig(
+        format='%(asctime)s %(levelname)-8s] %(message)s',
+        level=level,
+        datefmt='%Y-%m-%d %H:%M:%S'
+    )
 
 
 def main():
@@ -16,10 +36,14 @@ def main():
                         help="Directory for filesystem serializer storage (default: current directory)")
     parser.add_argument("--pg-connection-string", default=None,
                         help="PostgreSQL connection string (default: None)")
-    parser.add_argument("--host", default="127.0.0.1", help="Host to run the server on")
-    parser.add_argument("--port", type=int, default=5555, help="Port to run the server on")
+    parser.add_argument("--host", default="127.0.0.1", help="Host to run the server on (default: localhost)")
+    parser.add_argument("--port", type=int, default=5555, help="Port to run the server on (default: 5555)")
     parser.add_argument("--dev", action="store_true", help="Run in development mode")
+    parser.add_argument("--open", action="store_true", help="Opens the studio web UI in a browser")
+    parser.add_argument("--verbose", "-v", action="store_true", help="Enables debug logging for more verbose output")
     args = parser.parse_args()
+
+    _setup_logging(logging.DEBUG if args.verbose else logging.INFO)
 
     if args.dev:
         assert args.port == 5555, "Port must be 5000 in development mode"
@@ -30,18 +54,22 @@ def main():
 
     if not args.dev:
         # In production mode, serve the built React app
-        static_dir = os.path.join(os.path.dirname(__file__), "static")
+        static_dir = Path(__file__).parent / "static"
         # app.mount("/", StaticFiles(directory=static_dir, html=True), name="static")
 
         @app.get("/{full_path:path}")
         async def serve_react_app(full_path: str):
-            file_path = os.path.join(static_dir, full_path)
-            if os.path.exists(file_path) and os.path.isfile(file_path):
+            file_path = static_dir / full_path
+            if file_path.exists() and file_path.is_file():
                 return FileResponse(file_path)
             else:
-                return FileResponse(os.path.join(static_dir, "index.html"))
+                return FileResponse(static_dir / "index.html")
 
-    db_path = os.path.join(args.storage_dir)
+    if not args.storage_dir:
+        logger.warning("WARNING: Using current directory as the storage dir, pass --storage-dir to change this.")
+    db_path = Path(args.storage_dir or ".")
+    assert db_path.exists(), "Could not find path {db_path} (passed as --storage-dir), aborting!"
+    assert db_path.is_dir(), "Path {db_path} (passed as --storage-dir) is not a directory, aborting!"
 
     async def db_watcher(db_path, app):
         last_stat = None
@@ -49,10 +77,10 @@ def main():
         while True:
             await asyncio.sleep(0.1)  # Fixed interval of 0.1 seconds
             try:
-                current_stat = os.stat(db_path)
+                current_stat = db_path.stat()
                 
                 if last_stat is None:
-                    print(f"Database file found: {db_path}")
+                    logger.info(f"Database file found: {db_path}")
                     await app.notify_clients("database_updated")
                 else:
                     # Use a threshold for time comparison to account for filesystem differences
@@ -62,21 +90,35 @@ def main():
                     inode_changed = current_stat.st_ino != last_stat.st_ino
 
                     if time_changed or size_changed or inode_changed:
-                        print(f"Database changed: mtime {time.ctime(last_stat.st_mtime)} -> {time.ctime(current_stat.st_mtime)}, "
-                              f"size {last_stat.st_size} -> {current_stat.st_size}, "
-                              f"inode {last_stat.st_ino} -> {current_stat.st_ino}")
+                        logger.info(
+                            f"Database changed: mtime {time.ctime(last_stat.st_mtime)} -> {time.ctime(current_stat.st_mtime)}, "
+                            f"size {last_stat.st_size} -> {current_stat.st_size}, "
+                            f"inode {last_stat.st_ino} -> {current_stat.st_ino}"
+                        )
                         await app.notify_clients("database_updated")
                 
                 last_stat = current_stat
             except FileNotFoundError:
                 if last_stat is not None:
-                    print(f"Database file deleted: {db_path}")
+                    logger.info(f"Database file deleted: {db_path}")
                     await app.notify_clients("database_updated")
                 last_stat = None
                 await asyncio.sleep(1)  # Wait a bit longer if the file is missing
             except Exception as e:
-                print(f"Error checking database file: {e}")
+                logger.info(f"Error checking database file: {e}")
                 await asyncio.sleep(1)  # Wait a bit longer on errors
+
+    async def open_browser(host, port):
+        while True:
+            logger.debug(f"Checking TCP port {port} on {host} for readiness.")
+            if _socket_is_open(host, port):
+                url = f"http://{host}:{port}"
+                logger.debug(f"Port is open, launching {url}.")
+                webbrowser.open_new(url)
+                return
+
+            logger.debug(f"Port {port} was not open, retrying.")
+            await asyncio.sleep(.1)
 
     # Start the database watcher
     loop = asyncio.new_event_loop()
@@ -85,6 +127,8 @@ def main():
     server = uvicorn.Server(config)
     loop.create_task(server.serve())
     loop.create_task(db_watcher(db_path, app))
+    if args.open:
+        loop.create_task(open_browser(args.host, args.port))
     loop.run_forever()
 
 if __name__ == "__main__":

--- a/src/ell/studio/__main__.py
+++ b/src/ell/studio/__main__.py
@@ -48,6 +48,9 @@ def main():
     if args.dev:
         assert args.port == 5555, "Port must be 5000 in development mode"
 
+    if not args.storage_dir:
+        logger.warning("WARNING: Using current directory as the storage dir, pass --storage-dir to change this.")
+
     config = Config.create(storage_dir=args.storage_dir,
                     pg_connection_string=args.pg_connection_string)
     app = create_app(config)
@@ -65,11 +68,8 @@ def main():
             else:
                 return FileResponse(static_dir / "index.html")
 
-    if not args.storage_dir:
-        logger.warning("WARNING: Using current directory as the storage dir, pass --storage-dir to change this.")
-    db_path = Path(args.storage_dir or ".")
-    assert db_path.exists(), "Could not find path {db_path} (passed as --storage-dir), aborting!"
-    assert db_path.is_dir(), "Path {db_path} (passed as --storage-dir) is not a directory, aborting!"
+    # Respect Config.create behavior, which has fallback to env vars.
+    db_path = Path(config.storage_dir)
 
     async def db_watcher(db_path, app):
         last_stat = None


### PR DESCRIPTION
**Issue**
Currently, running `ell-studio` with no args fails unexpectedly with an unhandled `TypeError`:

```
om:ell kw$ uvx --from ell-ai[all] ell-studio
Traceback (most recent call last):
  File "/Users/kw/.cache/uv/archive-v0/yRhKWbo2kdkMVmJ2BWBWg/bin/ell-studio", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/kw/.cache/uv/archive-v0/yRhKWbo2kdkMVmJ2BWBWg/lib/python3.12/site-packages/ell/studio/__main__.py", line 44, in main
    db_path = os.path.join(args.storage_dir)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen posixpath>", line 76, in join
TypeError: expected str, bytes or os.PathLike object, not NoneType
om:ell kw$
```

**Changes**
  * Fix the default behavior (no args passed) to align with the documented default of cwd (via `ell.studio.config.Config`).
  * Port usage of `os.path` to `pathlib.Path`.
  * Port usage of `print()` to the `logger` module.
  * Add a `--open` flag to automatically open the UI in a browser on launch.
  * Add a `-v`/`--verbose` flag to change the log level from INFO -> DEBUG.

**Testing**
```
$ uv run --no-project --with toml --with pytest build.py
...
$ uvx poetry run ell-studio --open -v
...
$ uvx poetry run ell-studio --storage-dir=./ell_logs --open -v
```
and verified UI was functional.