### PR TITLE
add support for numpy version < 2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ include = [
 [tool.poetry.dependencies]
 python = ">=3.9"
 fastapi = "^0.111.1"
-numpy = "^2.0.1"
+numpy = ">=1.26.0"
 dill = "^0.3.8"
 colorama = "^0.4.6"
 cattrs = "^23.2.3"


### PR DESCRIPTION
I think its fine with numpy > 1.26.