### PR TITLE
removed hardcoded tool choice in openai provider in favour of a "get"…

### DIFF
--- a/src/ell/providers/openai.py
+++ b/src/ell/providers/openai.py
@@ -39,7 +39,7 @@ try:
                 final_call_params.pop("stream_options", None)
             if ell_call.tools:
                 final_call_params.update(
-                    tool_choice="auto",
+                    tool_choice=final_call_params.get("tool_choice", "auto"),
                     tools=[  
                         dict(
                             type="function",


### PR DESCRIPTION
… that defaults to "auto"

This addresses issue I was facing described in #227 