### PR TITLE
added preliminary caching impl

### DIFF
--- a/src/ell/store.py
+++ b/src/ell/store.py
@@ -3,7 +3,7 @@ from contextlib import contextmanager
 from datetime import datetime
 from typing import Any, Optional, Dict, List, Set, Union
 from ell.types._lstr import _lstr
-from ell.types import SerializedLMP, Invocation
+from ell.types import SerializedLMP, Invocation, InvocationContents
 from ell.types.message import InvocableLM
 
 class BlobStore(ABC):
@@ -56,6 +56,13 @@ class Store(ABC):
     def get_cached_invocations(self, lmp_id :str, state_cache_key :str) -> List[Invocation]:
         """
         Get cached invocations for a given LMP and state cache key.
+        """
+        pass
+
+    @abstractmethod
+    def get_cached_invocations_contents(self, lmp_id: str, state_cache_key: str) -> List[InvocationContents]:
+        """
+        Get cached invocation contents for a given LMP and state cache key.
         """
         pass
 

--- a/src/ell/stores/sql.py
+++ b/src/ell/stores/sql.py
@@ -76,7 +76,12 @@ class SQLStore(ell.store.Store):
     def get_cached_invocations(self, lmp_id :str, state_cache_key :str) -> List[Invocation]:
         with Session(self.engine) as session:
             return self.get_invocations(session, lmp_filters={"lmp_id": lmp_id}, filters={"state_cache_key": state_cache_key})
-        
+
+    def get_cached_invocations_contents(self, lmp_id :str, state_cache_key :str) -> List[Invocation]:
+        with Session(self.engine) as session:
+            cached_invocations = self.get_invocations(session, lmp_filters={"lmp_id": lmp_id}, filters={"state_cache_key": state_cache_key})
+            return [cached.contents for cached in cached_invocations]
+
     def get_versions_by_fqn(self, fqn :str) -> List[SerializedLMP]:
         with Session(self.engine) as session:
             return self.get_lmps(session, name=fqn)


### PR DESCRIPTION
Hoping to get your thoughts on this:
- get_cached_invocations_contents -> cannot access content on an Invocation outside of a db Session so created a new accessor function
- might I have to do something different for the text content?

My thoughts on next steps:
 1. add status to SerializedLMP to toggle on/off cached invocation
 2. expose this as an api to the frontend
 3. make changes in the frontend to toggle this on/off for individual LMPs
