### PR TITLE
Got <BV> to stop showing up in LMP deps

### DIFF
--- a/__testing__.py
+++ b/__testing__.py
@@ -1,0 +1,34 @@
+from typing import Optional
+import ell
+
+ell.init(
+    store="./logdir",
+    autocommit=True,
+    autocommit_model="claude-3-haiku-20240307",
+    verbose=True,
+)
+
+bound_global = "global"
+
+previous_letters = []
+@ell.simple(model="claude-3-haiku-20240307", max_tokens=15)
+def backwards_name():
+    """You are a helpful assistant that can think of a diverse range of first names. Only respond with the name and nothing else."""  # System Message
+    global previous_letters
+    if len(previous_letters) > 0 and len(previous_letters) <= 26:
+      # add 1 to the last letter
+      previous_letters.append(chr(ord(previous_letters[-1]) + 1))
+    else:
+      previous_letters = ["a"]
+    return f"Generate a new name, spelled backwards, not using any of the previous letters in: {previous_letters}."  # User Message
+
+@ell.simple(model="claude-3-haiku-20240307", max_tokens=100)
+def hello(world: Optional[str] = None):
+    """You are a helpful assistant that writes in the LOWER case."""  # System Message
+    if world is None:
+      world = backwards_name()
+      print(world)
+    return f"Say hello to {world[::-1]} with a poem. {bound_global}"  # User Message
+
+print(hello("sama"))
+print(hello())

--- a/ell-studio/src/components/source/DiffRenderer.js
+++ b/ell-studio/src/components/source/DiffRenderer.js
@@ -12,6 +12,14 @@ export function DiffRenderer({
 }) {
   if (!previousCode) return null;
 
+  function removeEllTags(code) {
+    const ellTagRegex = /\s*#\s*<\/?(BV|BmV|LMP)>/g;
+    return code.replace(ellTagRegex, '');
+  }
+
+  code = removeEllTags(code);
+  previousCode = removeEllTags(previousCode);
+
   var previousCodeRows = []
   var currentCodeRows = []
   const getHighlightedCode = (code, rowsCb) => {

--- a/ell-studio/src/components/source/LMPSourceView.js
+++ b/ell-studio/src/components/source/LMPSourceView.js
@@ -93,7 +93,7 @@ const LMPSourceView = ({ lmp, showDependenciesInitial = false, selectedInvocatio
         const lmp_name = match[1].split('(')[0];
         console.log(lmp_name);
         if (uses.some(u => u.name === lmp_name)) {
-          return `#<LMP>\n${line}\n#</LMP>`;
+          return `# <LMP>\n${line}\n# </LMP>`;
         }
       }
       return line;
@@ -121,21 +121,21 @@ const LMPSourceView = ({ lmp, showDependenciesInitial = false, selectedInvocatio
 
     return [{
     name: 'boundedVariable',
-    startTag: '#<BV>',
-    endTag: '#</BV>',
+    startTag: '# <BV>',
+    endTag: '# </BV>',
     wrapper: ({children, key, content}) => {
       return <>{children}</>
     }},
     {
       name: 'boundedMutableVariable',
-      startTag: '#<BmV>',
-      endTag: '#</BmV>',
+      startTag: '# <BmV>',
+      endTag: '# </BmV>',
       wrapper: mutableBVWrapper
     },
     {
       name: 'usedLMP',
-      startTag: '#<LMP>',
-      endTag: '#</LMP>',
+      startTag: '# <LMP>',
+      endTag: '# </LMP>',
       wrapper: ({children, selectedInvocation, content}) => {
         return <UsedLMPWrapper uses={uses} selectedInvocation={selectedInvocation} content={content}>{children}</UsedLMPWrapper>
       }

--- a/src/ell/studio/__main__.py
+++ b/src/ell/studio/__main__.py
@@ -39,6 +39,7 @@ def main():
     parser.add_argument("--host", default="127.0.0.1", help="Host to run the server on (default: localhost)")
     parser.add_argument("--port", type=int, default=5555, help="Port to run the server on (default: 5555)")
     parser.add_argument("--dev", action="store_true", help="Run in development mode")
+    parser.add_argument("--dev-static-dir", default=None, help="Directory to serve static files from in development mode")
     parser.add_argument("--open", action="store_true", help="Opens the studio web UI in a browser")
     parser.add_argument("--verbose", "-v", action="store_true", help="Enables debug logging for more verbose output")
     args = parser.parse_args()
@@ -64,6 +65,8 @@ def main():
                 return FileResponse(file_path)
             else:
                 return FileResponse(static_dir / "index.html")
+    elif args.dev_static_dir:
+        app.mount("/", StaticFiles(directory=args.dev_static_dir, html=True), name="static")
 
     # Respect Config.create behavior, which has fallback to env vars.
     db_path = Path(config.storage_dir) if config.storage_dir else None

--- a/src/ell/util/closure.py
+++ b/src/ell/util/closure.py
@@ -240,9 +240,9 @@ def _process_other_variable(var_name, var_value, dependencies, uses):
     if isinstance(var_value, str) and '\n' in var_value:
         dependencies.append(f"{var_name} = '''{var_value}'''")
     elif is_immutable_variable(var_value):
-        dependencies.append(f"#<BV>\n{var_name} = {repr(var_value)}\n#</BV>")
+        dependencies.append(f"# <BV>\n{var_name} = {repr(var_value)}\n# </BV>")
     else:
-        dependencies.append(f"#<BmV>\n{var_name} = <{type(var_value).__name__} object>\n#</BmV>")
+        dependencies.append(f"# <BmV>\n{var_name} = <{type(var_value).__name__} object>\n# </BmV>")
 
 def _build_initial_source(imports, dependencies, source):
     """Build the initial source code."""
@@ -327,11 +327,11 @@ def get_referenced_names(code: str, module_name: str):
     Returns:
     list: A list of all attributes of the module that are referenced in the code.
     """
-    # Remove content between #<BV> and #</BV> tags
-    code = re.sub(r'#<BV>\n.*?\n#</BV>', '', code, flags=re.DOTALL)
+    # Remove content between # <BV> and # </BV> tags
+    code = re.sub(r'# <BV>\n.*?\n# </BV>', '', code, flags=re.DOTALL)
     
-    # Remove content between #<BmV> and #</BmV> tags
-    code = re.sub(r'#<BmV>\n.*?\n#</BmV>', '', code, flags=re.DOTALL)
+    # Remove content between # <BmV> and # </BmV> tags
+    code = re.sub(r'# <BmV>\n.*?\n# </BmV>', '', code, flags=re.DOTALL)
 
     tree = ast.parse(code)
     referenced_names = []

--- a/src/ell/util/differ.py
+++ b/src/ell/util/differ.py
@@ -29,7 +29,7 @@ Response format:
 <Short commit message summarizing all the changes with specificity>:
 * <Bulleted list of each specific change>.
 """
-    clean_program_of_all_bv_tags = lambda program : program.replace("#<BV>", "").replace("#</BV>", "").replace("#<BmV>", "").replace("#</BmV>", "")
+    clean_program_of_all_bv_tags = lambda program : program.replace("# <BV>", "").replace("# </BV>", "").replace("# <BmV>", "").replace("# </BmV>", "")
     old_clean = clean_program_of_all_bv_tags(old)
     new_clean = clean_program_of_all_bv_tags(new)
 


### PR DESCRIPTION
Fix for #287 
* culprit is Black formatter adds space after # comment
* it doesn't always though because if the formatter raises exception, no format
* fixed by chaning `#<BV>` => `# <BV>` but for all tags

NOTE: this might not be the right way since without rerunning all the LMPs, the old source persists in the DB, so the old #<BV> tags won't get rendered right in the React app. Could instead enforce that # <BV> becomes #<BV> even after formatting, or strip out the delimiter before formatting and add it back in after.