### PR TITLE
Fix issue #310 but also autocommit when no OpenAI key present

### DIFF
--- a/src/ell/models/ollama.py
+++ b/src/ell/models/ollama.py
@@ -24,7 +24,7 @@ def register(base_url):
         It logs any errors encountered during the process.
     """
     global client
-    client = openai.Client(base_url=base_url)
+    client = openai.Client(base_url=base_url, api_key="ollama")
     
     try:
         response = requests.get(f"{base_url}/../api/tags")

--- a/src/ell/util/_warnings.py
+++ b/src/ell/util/_warnings.py
@@ -60,8 +60,8 @@ ell.simple(model, client=my_client)(...)
 
 
 def _autocommit_warning():
-    if (config.get_client_for("gpt-4o-mini")[0] is None):
-        logger.warning(f"{Fore.LIGHTYELLOW_EX}WARNING: Autocommit is enabled but no OpenAI client found for autocommit model 'gpt-4o-mini' (set your OpenAI API key). Commit messages will not be written.{Style.RESET_ALL}")
+    if (config.get_client_for(config.autocommit_model)[0] is None):
+        logger.warning(f"{Fore.LIGHTYELLOW_EX}WARNING: Autocommit is enabled but no client found for autocommit model '{config.autocommit_model}'. Commit messages will not be written.{Style.RESET_ALL}")
         return True
     return False
 


### PR DESCRIPTION
* OpenAI API requires there be a `api_key` field although Ollama's API doesn't require it
* Fixed `_autocommit_warning` to warn when there's no client for config.autocommit_model instead of hardcoded "gpt-4o-mini" string and updated warning message accordingly
#310 