### PR TITLE
Bedrock usage metadata

### DIFF
--- a/src/ell/providers/bedrock.py
+++ b/src/ell/providers/bedrock.py
@@ -147,15 +147,9 @@ try:
                     logger(tracked_results[0].text)
 
 
-                # usage = call_result.response.usage.dict() if call_result.response.get('usage') else {}
-                # metadata = call_result.response.model_dump()
-                # del metadata["content"]
-
-            # process metadata for ell
-            # XXX: Unify an ell metadata format for ell studio.
-            usage["prompt_tokens"] = usage.get("inputTokens", 0)
-            usage["completion_tokens"] = usage.get("outputTokens", 0)
-            usage["total_tokens"] = usage['prompt_tokens'] + usage['completion_tokens']
+                usage["prompt_tokens"] = provider_response.get('usage').get("inputTokens", 0)
+                usage["completion_tokens"] = provider_response.get('usage').get("outputTokens", 0)
+                usage["total_tokens"] = usage['prompt_tokens'] + usage['completion_tokens']
 
             metadata["usage"] = usage
             return tracked_results, metadata


### PR DESCRIPTION
For non streaming responses, Bedrock usage metadata was not being captured. Updated the metadata `dict` in line with how it was being handled for streaming responses.