### PR TITLE
Added session ID as a contextVar

### DIFF
--- a/src/ell/ctxt.py
+++ b/src/ell/ctxt.py
@@ -1,0 +1,17 @@
+from contextvars import ContextVar
+from uuid import uuid4
+
+session_id_context: ContextVar[str] = ContextVar('session_id', default='')
+
+def get_session_id() -> str:
+    """Get current session ID or create new one"""
+    session_id = session_id_context.get()
+    if not session_id:
+        session_id = str(uuid4())
+        session_id_context.set(session_id)
+    
+    return session_id
+
+def set_session_id(session_id: str) -> None:
+    """Set session ID in current context"""
+    session_id_context.set(session_id)

--- a/src/ell/store.py
+++ b/src/ell/store.py
@@ -53,6 +53,13 @@ class Store(ABC):
         pass
 
     @abstractmethod
+    def get_invocations_by_session_id(self, session_id: str) -> List[Invocation]:
+        """
+        Get all invocations for a given session ID.
+        """
+        pass
+
+    @abstractmethod
     def get_cached_invocations(self, lmp_id :str, state_cache_key :str) -> List[Invocation]:
         """
         Get cached invocations for a given LMP and state cache key.

--- a/src/ell/stores/sql.py
+++ b/src/ell/stores/sql.py
@@ -73,6 +73,10 @@ class SQLStore(ell.store.Store):
             session.commit()
             return None
         
+    def get_invocations_by_session_id(self, session_id: str) -> List[Invocation]:
+        with Session(self.engine) as session:
+            return self.get_invocations(session, lmp_filters={}, filters={"session_id": session_id})
+
     def get_cached_invocations(self, lmp_id :str, state_cache_key :str) -> List[Invocation]:
         with Session(self.engine) as session:
             return self.get_invocations(session, lmp_filters={"lmp_id": lmp_id}, filters={"state_cache_key": state_cache_key})

--- a/src/ell/types/studio.py
+++ b/src/ell/types/studio.py
@@ -114,6 +114,7 @@ class InvocationBase(SQLModel):
     completion_tokens: Optional[int] = Field(default=None)
     state_cache_key: Optional[str] = Field(default=None)
     created_at: datetime = UTCTimestampField(default=func.now(), nullable=False)
+    session_id: Optional[str] = Field(default=None)
     used_by_id: Optional[str] = Field(default=None, foreign_key="invocation.id", index=True)
     # global_vars and free_vars removed from here
 


### PR DESCRIPTION
This works well with server applications with async support, as a common use case is aggregating the token cost per API request. I believe this is also in-line with ell design philosophy of relying on Python language features (ie. ell.config as a global variable) to promote ell lifecycle operations