### PR TITLE
role=role or "assistant"

### DIFF
--- a/src/ell/providers/openai.py
+++ b/src/ell/providers/openai.py
@@ -123,7 +123,7 @@ try:
                 for _, message_stream in sorted(message_streams.items(), key=lambda x: x[0]):
                     text = "".join((choice.delta.content or "") for choice in message_stream)
                     messages.append(
-                        Message(role=role, 
+                        Message(role=role or "assistant",
                                 content=_lstr(content=text,origin_trace=origin_id)))
                     #XXX: Support streaming other types.
             else:


### PR DESCRIPTION
Message(role=role,
                                content=_lstr(content=text,origin_trace=origin_id)))
sometimes role is empty and will throw exception:
```
pydantic_core._pydantic_core.ValidationError: 1 validation error for Message
role
  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
    For further information visit https://errors.pydantic.dev/2.9/v/string_type
python-BaseException
```