### PR TITLE
[ell-studio] Update CodeSection clickable area and fix overlapping Invocation Panes

### DIFF
--- a/ell-studio/src/components/invocations/details/InvocationDetailsPopover.js
+++ b/ell-studio/src/components/invocations/details/InvocationDetailsPopover.js
@@ -7,6 +7,7 @@ import InvocationDataPane from './InvocationDataPane';
 import { motion } from 'framer-motion';
 import { LMPCardTitle } from "../../depgraph/LMPCardTitle";
 import { Card } from "../../common/Card";
+import { ScrollArea } from "@radix-ui/react-scroll-area";
 
 const InvocationDetailsPopover = ({ invocation, onClose, onResize }) => {
   const [activeTab, setActiveTab] = useState("I/O");
@@ -102,14 +103,14 @@ const InvocationDetailsPopover = ({ invocation, onClose, onResize }) => {
             transition={{ duration: 0.2 }}
           >
             {activeTab === "I/O" && (
-              <div className="h-full">
+              <ScrollArea>
                 <InvocationDataPane invocation={invocation} />
-              </div>
+              </ScrollArea>
             )}
             {(activeTab === "Info" || isNarrowForInfo) && (
-              <div className="h-full">
+              <ScrollArea>
                 <InvocationInfoPane invocation={invocation} isFullWidth={true} />
-              </div>
+              </ScrollArea>
             )}
           </motion.div>
           {!isNarrowForInfo && activeTab === "I/O" && (

--- a/ell-studio/src/components/source/CodeSection.js
+++ b/ell-studio/src/components/source/CodeSection.js
@@ -54,12 +54,8 @@ export function CodeSection({
     };
 
     return (
-      <div className="code-section mb-4">
-        <div onClick={(e) => {
-          if (e.target === e.currentTarget) {
-            setShowCode(!showCode);
-          }
-        }}
+      <div className="code-section mb-4" onClick={() => setShowCode(!showCode)}>
+        <div 
           className="section-header flex items-center justify-between w-full text-sm text-gray-300 
           hover:text-white py-2 px-4 rounded-t-md bg-gray-800 hover:bg-gray-700 transition-colors 
           duration-200 cursor-pointer">
@@ -70,7 +66,7 @@ export function CodeSection({
             {showCode ? <FiChevronDown className="mr-2" /> : <FiChevronRight className="mr-2" />}
             {title}
           </button>
-          <div className="flex items-center">
+          <div className="flex items-center" onClick={(e) => e.stopPropagation()}>
             {enableFormatToggle && (
               <button
                 onClick={toggleFormat}


### PR DESCRIPTION
This PR updates CodeSection so the user can collapse the displayed code by clicking anywhere within the component. Previously you can only collapse code by clicking on the header, which means you have to scroll all the way up to header if your result text is long. 

It also fixes the issue of the invocation panes overlapping on certain screen sizes (see below) by wrapping each pane in a ScrollArea.

![DivIssue](https://github.com/user-attachments/assets/77b5638a-601f-4602-b29c-3686a7601491)
