### PR TITLE
fix: version requirement too strict for `sqlmodel`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ cattrs = "^23.2.3"
 openai = "^1.51.0"
 anthropic = { version = "^0.34.2", optional = true }
 groq = { version = "^0.11.0", optional = true }
-sqlmodel = "^0.0.21"
+sqlmodel = ">=0.0.21, <0.1.0"
 uvicorn = "^0.30.3"
 requests = "^2.32.3"
 typing-extensions = "^4.12.2"


### PR DESCRIPTION
Previous caret version requirement `^0.0.21` for sqlmodel only allows version ">=0.0.21, <0.0.22" and seems too strict. Changing to `>=0.0.21, <0.1.0` to allow newer versions.

Ref to Poetry documentation: [Caret requirements - Dependency specification](https://python-poetry.org/docs/dependency-specification/#caret-requirements)
> 0.0.x is not considered compatible with any other version.