### PR TITLE
Fix tool call ID in message object

### DIFF
--- a/src/ell/providers/openai.py
+++ b/src/ell/providers/openai.py
@@ -83,7 +83,8 @@ try:
                         role=message.role,
                         content=[_content_block_to_openai_format(c) for c in message.content] 
                              if message.role != "system" 
-                             else message.text_only
+                             else message.text_only,
+                        tool_call_id=message.tool_call_id
                     )))
                      
             final_call_params["messages"] = openai_messages
@@ -159,7 +160,7 @@ try:
                                     )
                                 )
                                 if logger: logger(repr(tool_call))
-                    messages.append(Message(role=role, content=content_blocks))
+                    messages.append(Message(role=role, content=content_blocks, tool_call_id=message.tool_call_id))
             return messages, metadata
 
 

--- a/src/ell/types/message.py
+++ b/src/ell/types/message.py
@@ -312,12 +312,11 @@ def to_content_blocks(
 class Message(BaseModel):
     role: str
     content: List[ContentBlock]
-    
+    tool_call_id: Optional[_lstr_generic] = Field(default=None)
 
-    def __init__(self, role: str, content: Union[AnyContent, List[AnyContent], None] = None, **content_block_kwargs):
+    def __init__(self, role: str, content: Union[AnyContent, List[AnyContent], None] = None, tool_call_id: Optional[_lstr_generic] = None, **content_block_kwargs):
         content_blocks = to_content_blocks(content, **content_block_kwargs)
-        
-        super().__init__(role=role, content=content_blocks)
+        super().__init__(role=role, content=content_blocks, tool_call_id=tool_call_id)
 
     # XXX: This choice of naming is unfortunate, but it is what it is.
     @property
@@ -452,6 +451,8 @@ class Message(BaseModel):
                     else:
                         content_blocks.append(ContentBlock.coerce(block))
                 obj['content'] = content_blocks
+            if 'tool_call_id' in obj:
+                obj['tool_call_id'] = _lstr(obj['tool_call_id'])
         return super().model_validate(obj)
 
     @classmethod


### PR DESCRIPTION
Fixes #325

Add `tool_call_id` attribute to `Message` class and update methods to handle it.

* Add `tool_call_id` attribute to `Message` class in `src/ell/types/message.py`.
* Update `__init__` method in `Message` class to accept `tool_call_id` parameter.
* Update `model_validate` method in `Message` class to handle `tool_call_id`.
* Update `translate_to_provider` method in `src/ell/providers/openai.py` to add `tool_call_id` to `Message` object.
* Update `translate_from_provider` method in `src/ell/providers/openai.py` to process `tool_call_id` in `Message` object.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/MadcowD/ell/issues/325?shareId=e5c0155e-e408-48b4-8e2d-8348bc38dfde).