### PR TITLE
fix getsource for jupyter context

### DIFF
--- a/src/ell/util/closure.py
+++ b/src/ell/util/closure.py
@@ -83,7 +83,7 @@ def lexical_closure(
     while hasattr(func, "__ell_func__"):
         func = func.__ell_func__
 
-    source = getsource(func, lstrip=True)
+    source = getsource(func, lstrip=True, force=True)
     already_closed.add(hash(func))
 
     globals_and_frees = _get_globals_and_frees(func)


### PR DESCRIPTION
Don't know if this creates any other issues but the problem seemed to be that by default, getsource is looking for the source filename which in jupyter doesn't exist.