### PR TITLE
fix: update install scripts to use quotes for zsh compatibility

### DIFF
--- a/docs/src/installation.rst
+++ b/docs/src/installation.rst
@@ -10,7 +10,7 @@ Installing ell
 
    .. code-block:: bash
 
-      pip install -U ell-ai[all]
+      pip install -U "ell-ai[all]"
 
    This installs ``ell``, ``ell-studio``, versioning and tracing with SQLite, and the default provider clients.
 
@@ -39,7 +39,7 @@ Adds the Anthropic client.
 
 .. code-block:: bash
 
-   pip install -U ell-ai[anthropic]
+   pip install -U "ell-ai[anthropic]"
 
 
 ``groq``
@@ -48,7 +48,7 @@ Adds the Groq client.
 
 .. code-block:: bash
 
-   pip install -U ell-ai[groq]
+   pip install -U "ell-ai[groq]"
 
 
 ``studio``
@@ -57,7 +57,7 @@ Adds ``ell-studio``.
 
 .. code-block:: bash
 
-   pip install -U ell-ai[studio]
+   pip install -U "ell-ai[studio]"
 
 
 ``sqlite``
@@ -66,7 +66,7 @@ SQLite storage for versioning and tracing.
 
 .. code-block:: bash
 
-   pip install -U ell-ai[sqlite]
+   pip install -U "ell-ai[sqlite]"
 
 
 ``postgres``
@@ -77,7 +77,7 @@ Include this option if you'd like to use ``ell-studio`` with Postgres.
 
 .. code-block:: bash
 
-   pip install -U ell-ai[postgres]
+   pip install -U "ell-ai[postgres]"
 
 Combining options
 ~~~~~~~~~~~~~~~~~
@@ -88,7 +88,7 @@ Example: Install ``ell`` with ``ell-studio``, Postgres, and the Anthropic client
 
 .. code-block:: bash
 
-   pip install -U ell-ai[studio, postgres, anthropic]
+   pip install -U "ell-ai[studio, postgres, anthropic]"
 
 
 API Key Setup

--- a/src/ell/stores/__init__.py
+++ b/src/ell/stores/__init__.py
@@ -1,4 +1,5 @@
 try:
     import sqlmodel
 except ImportError:
-    raise ImportError("ell.stores has missing dependencies. Install them with `pip install -U ell-ai[sqlite]` or `pip install -U ell-ai[postgres]`. More info: https://docs.ell.so/installation/custom-installation")
+    raise ImportError(
+        'ell.stores has missing dependencies. Install them with `pip install -U "ell-ai[sqlite]"` or `pip install -U "ell-ai[postgres]"`. More info: https://docs.ell.so/installation/custom-installation')

--- a/src/ell/studio/__init__.py
+++ b/src/ell/studio/__init__.py
@@ -2,4 +2,5 @@ try:
     import fastapi
     import ell.stores
 except ImportError:
-    raise ImportError("ell.studio is missing dependencies. Install them with `pip install -U ell-ai[studio]. More info: https://docs.ell.so/installation/custom-installation")
+    raise ImportError(
+        'ell.studio is missing dependencies. Install them with `pip install -U "ell-ai[studio]"`. More info: https://docs.ell.so/installation/custom-installation')


### PR DESCRIPTION
Adding quotes to the installation script makes it compatible with zsh shells, while still working with any other shell. Example: `pip install -U "ell-ai[all]"`. Basically the problem is that the square brackets have special meaning in ZSH as they're used for pattern matching, so the shell is trying to interpret `[all]` as a pattern rather than passing it literally to pip.