### PR TITLE
fix: Corrected Evaluation Example

### DIFF
--- a/ell-studio/src/pages/Evaluations.js
+++ b/ell-studio/src/pages/Evaluations.js
@@ -69,8 +69,7 @@ def metric(datapoint, output):
 # Initialize your evaluation
 eval = Evaluation(
     name="basic-eval",
-    dataset=[{"input": "Hello", "expected": "Hi there!"}],
-    n_evals=10,
+    dataset=[{"input": ["Hello"], "expected": "Hi there!"}],
     metrics={"score": metric}
 )
 


### PR DESCRIPTION
Removed `n_evals=10,`
Made input into a list `    dataset=[{"input": ["Hello"], "expected": "Hi there!"}],`