### PR TITLE
Use pydantic field validator to serialize ToolCall callable (#412)

### DIFF
--- a/src/ell/types/_lstr.py
+++ b/src/ell/types/_lstr.py
@@ -116,7 +116,8 @@ class _lstr(str):
         def validate_lstr(value):
             if isinstance(value, dict) and value.get("__lstr", False):
                 content = value["content"]
-                origin_trace = value["__origin_trace__"].split(",")
+                ot_value = value["__origin_trace__"]
+                origin_trace = ot_value.split(",") if hasattr(ot_value, "split") else ot_value
                 return cls(content, origin_trace=origin_trace)
             elif isinstance(value, str):
                 return cls(value)

--- a/tests/test_tool_call_serialization.py
+++ b/tests/test_tool_call_serialization.py
@@ -1,0 +1,19 @@
+import pytest
+
+# must be imported from classpath, not src.., to match Pydantic type FQNs
+from ell.types import ContentBlock, ToolCall, Message 
+from src.ell.lmp.tool import tool
+
+@pytest.mark.skip('helper @tool()-wrapped function, not an actual test')
+@tool()
+def test_tool() -> ContentBlock:
+    return ContentBlock(text="success!")
+
+def test_tool_call_json_serialization():
+    original_message = Message(role='assistant', content=[ToolCall(test_tool, params={}, tool_call_id="a")])
+    message_json = original_message.model_dump_json()
+
+    loaded_message = Message.model_validate_json(message_json)
+
+    tool_result = loaded_message.call_tools_and_collect_as_message()
+    assert tool_result.content[0].tool_result.text == "success!"


### PR DESCRIPTION
ToolCall's `tool` is a Callable, which isn't serializable by Pydantic. This PR adds a @field_serializer and @field_validator that serialize the tool's FQN and then resolve the named function when validating from serialized form.

