### PR TITLE
[bug fix] prompt_tokens is 0 when using sonnet

### DIFF
--- a/src/ell/providers/anthropic.py
+++ b/src/ell/providers/anthropic.py
@@ -146,7 +146,7 @@ try:
             
             # process metadata for ell
             # XXX: Unify an ell metadata format for ell studio.
-            usage["prompt_tokens"] = usage.get("input_tokens", 0)
+            usage["prompt_tokens"] = metadata.get("usage", {}).get("input_tokens", 0)
             usage["completion_tokens"] = usage.get("output_tokens", 0)
             usage["total_tokens"] = usage['prompt_tokens'] + usage['completion_tokens']
 

--- a/src/ell/providers/anthropic.py
+++ b/src/ell/providers/anthropic.py
@@ -150,7 +150,7 @@ try:
             usage["completion_tokens"] = usage.get("output_tokens", 0)
             usage["total_tokens"] = usage['prompt_tokens'] + usage['completion_tokens']
 
-            metadata["usage"] = usage
+            metadata["usage"] = {**usage, **metadata.get("usage", {})}
             return tracked_results, metadata
 
     # XXX: Make a singleton.


### PR DESCRIPTION
Fix the issue that causes the prompt_tokens in the metadata to become 0 when using Claude Sonnet.