### PR TITLE
Fix init() unable to disable autocommit once enabled

### DIFF
--- a/src/ell/configurator.py
+++ b/src/ell/configurator.py
@@ -230,7 +230,7 @@ def init(
                 'Failed importing SQLiteStore. Install with `pip install -U "ell-ai[all]"`. More info: https://docs.ell.so/installation')
     else:
         config.store = store
-    config.autocommit = autocommit or config.autocommit
+    config.autocommit = autocommit
 
     if default_api_params is not None:
         config.default_api_params.update(default_api_params)
@@ -261,3 +261,4 @@ def register_provider(provider: Provider, client_type: Type[Any]) -> None:
 def set_store(*args, **kwargs) -> None:
     raise DeprecationWarning(
         "The set_store function is deprecated and will be removed in a future version. Use ell.init(store=...) instead.")
+


### PR DESCRIPTION
## Summary

`ell.init(autocommit=False)` doesn't work if autocommit was previously enabled.

### Problem

In `configurator.py`, `init()` uses:
```python
config.autocommit = autocommit or config.autocommit
```

The `or` operator means that once `autocommit` is `True`, it can never be set back to `False`:
- First call: `init(autocommit=True)` → `True or False` → `True` ✓
- Second call: `init(autocommit=False)` → `False or True` → `True` ✗ (expected `False`)

### Fix

Use direct assignment:
```python
config.autocommit = autocommit
```

This respects the caller's explicit intent. The default value in the function signature (`autocommit: bool = True`) still provides a sensible default for callers who don't specify it.

### Reproduction

```python
import ell

ell.init(autocommit=True)
print(ell.config.autocommit)  # True

ell.init(autocommit=False)
print(ell.config.autocommit)  # True (bug!) — should be False
```
